### PR TITLE
Skip CI environment

### DIFF
--- a/.vscode/cSpell.json
+++ b/.vscode/cSpell.json
@@ -6,6 +6,7 @@
         "applypatch",
         "captaingithook",
         "captaingithookrc",
+        "cidetective",
         "circleci",
         "cobertura",
         "codecov",

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3 // indirect
+	github.com/swellaby/ci-detective v0.0.0-20181104023850-a40a44cae568
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,13 @@
 github.com/Masterminds/semver v1.4.2 h1:WBLTQ37jOCzSLtXNdoo8bNM8876KhNqOKvrlGITgsTc=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/spf13/cobra v0.0.3 h1:ZlrZ4XsMRm04Fr5pSFxBgfND2EBVa1nLpiy1stUsX/8=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/swellaby/ci-detective v0.0.0-20181104023850-a40a44cae568 h1:j9pGKL0c7wchxK/ePgVG78y99GijnRWOKR+gAadZnGA=
+github.com/swellaby/ci-detective v0.0.0-20181104023850-a40a44cae568/go.mod h1:TtR7ki9KZBqZQsd2ccLL5z8Y5kEMxzNR55IVg7V4JN4=

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -3,10 +3,12 @@ package cli
 import (
 	"github.com/spf13/cobra"
 	"github.com/swellaby/captain-githook/captaingithook"
+	"github.com/swellaby/ci-detective/cidetective"
 )
 
 var initializeCaptainGithook = captaingithook.Initialize
 var initializeCaptainGithookWithConfigName = captaingithook.InitializeWithFileName
+var isCI = cidetective.IsCI
 var initConfigFileName string
 
 var initCmd = &cobra.Command{
@@ -21,6 +23,10 @@ func init() {
 
 func initialize(*cobra.Command, []string) error {
 	log("Ahoy there matey!")
+	if isCI() {
+		log("CI environment detected. Skipping git hook install.")
+		return nil
+	}
 	if len(initConfigFileName) < 1 {
 		log("Initializing your repository with the default config file name.")
 		return initializeCaptainGithook()


### PR DESCRIPTION
## Changes
Summary of changes included in this PR:
- [X] Adds logic to skip hook install/setup when a CI environment is detected

## Issues Completed
- Closes #29 
