### PR TITLE
chore: bumped version to 0.1.0 in prep for dropping Go 1.11 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ We'll be adding binary releases shortly, but for now you'll need to have your [G
 go get -u github.com/swellaby/captain-githook
 ```
 
+Note that the latest `captain-githook` version requires Go 1.12 or higher. If you need to use `captain-githook` on Go 1.11 and earlier, make sure you use the `v0.0.7` tag:
+
+```sh
+go get -u github.com/swellaby/captain-githook@v0.0.7
+```
+
 This will ensure that the captain-githook executable is available on your system for initializing your repositories (creating git hook and config files) as well as for executing your defined hook scripts.
 
 ## Getting Started

--- a/captaingithook/version.go
+++ b/captaingithook/version.go
@@ -1,4 +1,4 @@
 package captaingithook
 
 // Version defines the current version of the package
-const Version = "0.0.7"
+const Version = "0.1.0"


### PR DESCRIPTION
## Changes
Summary of changes included in this PR:
- [X] Bumped minor version as part of dropping support for Go 1.11
- [X] Updated docs with `go get` instructions for Go 1.11 and earlier

## Issues Completed
- Closes #44 